### PR TITLE
Fix duplicate @ symbol when clicking character mention hints

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -341,7 +341,13 @@ function setupMentionHints() {
       const cursor = $input.selectionStart;
       const before = $input.value.slice(0, cursor);
       const after = $input.value.slice(cursor);
-      $input.value = before + `@${name} ` + after;
+      
+      if (before.endsWith("@")) {
+        $input.value = before.slice(0, -1) + `@${name} ` + after;
+      } else {
+        $input.value = before + `@${name} ` + after;
+      }
+      
       $input.focus();
       $mentionHints.classList.add("hidden");
     });


### PR DESCRIPTION
This PR fixes the bug where clicking on a character mention hint would insert two @ symbols instead of one. The fix checks if the text before the cursor already ends with @ and removes it before inserting the complete mention.