### PR TITLE
feat: 添加角色设置功能，支持自定义昵称和自动头像

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,13 +22,13 @@
       <header id="chat-header">
         <div class="chat-title">
           <h1>AI Chat Arena</h1>
-          <span class="chat-subtitle">Faker (Claude) & 奇迹哥 (Trae) & YYF (Codex)</span>
+          <span id="chat-subtitle" class="chat-subtitle">Faker (Claude) & 奇迹哥 (Trae) & YYF (Codex)</span>
         </div>
       </header>
 
       <main id="chat-container">
         <div id="messages">
-          <div class="system-notice">
+          <div id="system-notice" class="system-notice">
             输入 <code>@Faker</code> 调用 Claude，<code>@奇迹哥</code> 调用 Trae，<code>@YYF</code> 调用 Codex
           </div>
         </div>
@@ -55,9 +55,9 @@
         <h3>消息统计</h3>
         <div id="message-stats">
           <div class="stat-row"><span>总数</span><span id="stat-total">0</span></div>
-          <div class="stat-row"><span>Faker 消息</span><span id="stat-faker">0</span></div>
-          <div class="stat-row"><span>奇迹哥 消息</span><span id="stat-qijige">0</span></div>
-          <div class="stat-row"><span>YYF 消息</span><span id="stat-yyf">0</span></div>
+          <div class="stat-row"><span id="label-stat-faker">Faker 消息</span><span id="stat-faker">0</span></div>
+          <div class="stat-row"><span id="label-stat-qijige">奇迹哥 消息</span><span id="stat-qijige">0</span></div>
+          <div class="stat-row"><span id="label-stat-yyf">YYF 消息</span><span id="stat-yyf">0</span></div>
           <div class="stat-row"><span>验证通过</span><span id="stat-verified">0</span></div>
         </div>
       </div>
@@ -68,6 +68,27 @@
         </div>
       </div>
     </aside>
+  </div>
+
+  <button id="settings-btn" title="角色设置" aria-label="角色设置">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="3"></circle>
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.87l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06A1.7 1.7 0 0 0 15 19.4a1.7 1.7 0 0 0-1 .6 1.7 1.7 0 0 0-.4 1.08V21a2 2 0 1 1-4 0v-.12A1.7 1.7 0 0 0 9.2 20a1.7 1.7 0 0 0-1-.6 1.7 1.7 0 0 0-1.87.34l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-.6-1 1.7 1.7 0 0 0-1.08-.4H2.8a2 2 0 1 1 0-4h.12A1.7 1.7 0 0 0 4 9.2a1.7 1.7 0 0 0 .6-1 1.7 1.7 0 0 0-.34-1.87l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.7 1.7 0 0 0 9.2 4.6a1.7 1.7 0 0 0 1-.6 1.7 1.7 0 0 0 .4-1.08V2.8a2 2 0 1 1 4 0v.12A1.7 1.7 0 0 0 15 4a1.7 1.7 0 0 0 1 .6 1.7 1.7 0 0 0 1.87-.34l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.7 1.7 0 0 0 19.4 9c.34.3.54.72.6 1.18.01.2.01.41 0 .62-.06.46-.26.88-.6 1.18z"></path>
+    </svg>
+  </button>
+
+  <div id="settings-modal" class="modal hidden">
+    <div class="modal-backdrop" data-close="1"></div>
+    <div class="modal-panel">
+      <h3>角色设置</h3>
+      <p class="modal-desc">修改显示昵称。头像会自动取昵称首个中文或首字符，发送消息时会自动映射到原角色。</p>
+      <div id="settings-error" class="settings-error hidden"></div>
+      <div id="settings-form"></div>
+      <div class="modal-actions">
+        <button id="settings-cancel-btn" class="btn-secondary">取消</button>
+        <button id="settings-save-btn" class="btn-primary">保存</button>
+      </div>
+    </div>
   </div>
 
   <script src="app.js"></script>

--- a/public/style.css
+++ b/public/style.css
@@ -347,10 +347,107 @@ html, body { height: 100%; font-family: -apple-system, "PingFang SC", "Segoe UI"
 .char-status-name { flex: 1; }
 .char-status-label { font-size: 11px; color: var(--text-light); }
 
+/* ── 设置按钮与弹窗 ───────────────────── */
+#settings-btn {
+  position: fixed;
+  left: 16px;
+  bottom: 16px;
+  width: 46px;
+  height: 46px;
+  border: none;
+  border-radius: 50%;
+  background: var(--header-bg);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 50;
+}
+#settings-btn svg { width: 22px; height: 22px; }
+#settings-btn:hover { opacity: 0.92; }
+
+.modal.hidden { display: none; }
+.modal {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+.modal-panel {
+  position: relative;
+  width: min(560px, calc(100vw - 24px));
+  margin: 8vh auto 0;
+  background: white;
+  border-radius: 14px;
+  padding: 18px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.24);
+}
+.modal-panel h3 { font-size: 18px; margin-bottom: 6px; }
+.modal-desc { font-size: 13px; color: var(--text-light); margin-bottom: 14px; }
+.settings-error {
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: #fff2f2;
+  color: var(--error-text);
+  font-size: 12px;
+}
+.settings-error.hidden { display: none; }
+
+#settings-form {
+  display: grid;
+  gap: 10px;
+}
+.setting-row {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 8px;
+  align-items: center;
+}
+.setting-row .setting-cli {
+  font-size: 12px;
+  color: var(--text-light);
+}
+.setting-row input {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+}
+.modal-actions {
+  margin-top: 14px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.btn-primary, .btn-secondary {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.btn-primary {
+  background: var(--faker-accent);
+  color: white;
+}
+.btn-secondary {
+  background: #ececf3;
+  color: var(--text);
+}
+
 /* ── 响应式：窄屏隐藏侧边栏 ─────────── */
 @media (max-width: 900px) {
   #app { grid-template-columns: 1fr; }
   #sidebar-left, #sidebar-right { display: none; }
+  #settings-btn { left: 12px; bottom: 12px; }
+  .setting-row { grid-template-columns: 1fr; }
 }
 @media (min-width: 901px) and (max-width: 1100px) {
   #app { grid-template-columns: 200px 1fr; }


### PR DESCRIPTION
添加了角色设置功能，用户可以自定义角色昵称。主要功能包括：

- 新增设置按钮和设置弹窗
- 支持为每个角色设置自定义昵称
- 头像自动从昵昵称中提取（优先中文首字，否则首字符）
- 发送消息时自动将昵称映射回原角色名
- 昵称设置保存在localStorage中
- 防止昵称重复的验证机制
- 更新了聊天界面、消息统计和会话列表中的角色显示